### PR TITLE
Ticket1436: config version control ignores rcptt files

### DIFF
--- a/config_version_control.py
+++ b/config_version_control.py
@@ -1,6 +1,9 @@
+import os
+import shutil
 from version_control_wrapper import VersionControlWrapper
 from constants import *
 
+SYSTEM_TEST_PREFIX = "rcptt_"
 
 class ConfigVersionControl:
 
@@ -11,9 +14,21 @@ class ConfigVersionControl:
     #i.e. not automatically via the file observer firing an event, but after a new configuration is created
     #or an existing one updated via the GUI.
     def add(self, file_path):
+        if self._should_ignore(file_path):
+            return
+
         self.version_control.add(file_path)
 
     def remove(self, file_path):
+        if self._should_ignore(file_path) and os.path.exists(file_path):
+            # the git library throws if we try to delete something that wasn't added
+            # but we still have to delete the file from file system
+            if os.path.isdir(file_path):
+                shutil.rmtree(file_path)
+            else:
+                os.remove(file_path)
+            return
+
         self.version_control.remove(file_path)
 
     #and supply a message for the commit (e.g. change to configuration)
@@ -25,6 +40,13 @@ class ConfigVersionControl:
         if update_path == "":
             update_path = self.working_directory
         self.version_control.update(update_path)
+
+    def _should_ignore(self, file_path):
+        # Ignore anything that starts with the system tests prefix
+        # (unfortunately putting the system test prefix in the .gitignore doesn't work
+        # because the git library always forces an add - it has a force flag, but it's not used)
+        return SYSTEM_TEST_PREFIX in file_path
+
 
 if __name__ == "__main__":
     path = "C:\Instrument\Settings\config\\test_git\\test"


### PR DESCRIPTION
This is for ticket ISISComputingGroup/IBEX#1436

The git config version control now ignores any file containing the system test rcptt prefix in its path, both on add and remove.
The usual git library remove command would normally take care of deleting the file from the file system too, so this is something that now we have to take care of ourselves with the rcptt files.

To test:
Run the instrument and the GUI. Save anything (synoptic or configuration etc.) containing "rcptt_" in its name. Go to the Config repository and verify that the new files were not added to git (if you do this via the git bash, remember to close it before trying to operate again - on my machine the blockserver starts winging if I have that repository open).
Then through the GUI delete what you've just created. All should behave normally without git errors from the blockserver, and if you look at the Config folder the files should have been correctly deleted.
